### PR TITLE
Fixed Typo: Missing paren

### DIFF
--- a/source/_posts/2016-07-13-advanced-debugging.markdown
+++ b/source/_posts/2016-07-13-advanced-debugging.markdown
@@ -153,7 +153,7 @@ I have a friend who is a very talented software engineer and mathematician. One 
 
 ```js
 for (var i = 0; i < 10; i++) {
-  for (var i = 0; i < 5; i++ {
+  for (var i = 0; i < 5; i++) {
     // logic
   }
 }


### PR DESCRIPTION
Someone noticed that I had a missing parenthesis during my talk today. This will hopefully be the last typo fix.