### PR TITLE
Remove duplicate javascript and prevent error on search return

### DIFF
--- a/2013/02/composable-mapreduce-with-hadoop-and-crunch/index.html
+++ b/2013/02/composable-mapreduce-with-hadoop-and-crunch/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -341,16 +342,6 @@ Start with the questions to be answered, then model the data to answer them.
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/02/evangelizing-user-experience/index.html
+++ b/2013/02/evangelizing-user-experience/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -295,16 +296,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/02/near-real-time-processing-over-hadoop-and-hbase/index.html
+++ b/2013/02/near-real-time-processing-over-hadoop-and-hbase/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -374,16 +375,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/02/why-engineering-health/index.html
+++ b/2013/02/why-engineering-health/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -282,16 +283,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/03/cerner-and-tycho/index.html
+++ b/2013/03/cerner-and-tycho/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -352,16 +353,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/03/modularity-in-medical-imaging/index.html
+++ b/2013/03/modularity-in-medical-imaging/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -316,16 +317,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/04/first-robotics-championship-competition-in-st-louis/index.html
+++ b/2013/04/first-robotics-championship-competition-in-st-louis/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -322,16 +323,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/04/learn-what-the-rules-dont-cover/index.html
+++ b/2013/04/learn-what-the-rules-dont-cover/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -293,16 +294,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/04/ruby-at-cerner/index.html
+++ b/2013/04/ruby-at-cerner/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -294,16 +295,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/07/thinking-in-mapreduce/index.html
+++ b/2013/07/thinking-in-mapreduce/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -330,16 +331,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/08/devacademy/index.html
+++ b/2013/08/devacademy/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -328,16 +329,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/08/devcon/index.html
+++ b/2013/08/devcon/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -298,16 +299,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/08/the-30-days-of-code-experiment/index.html
+++ b/2013/08/the-30-days-of-code-experiment/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -304,16 +305,6 @@ Using Node.js to flash lights on a Raspberry Pi when a health check from web ser
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/09/project-lead-the-way/index.html
+++ b/2013/09/project-lead-the-way/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -318,16 +319,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/11/2013-software-intern-hackfest/index.html
+++ b/2013/11/2013-software-intern-hackfest/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -370,16 +371,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2013/11/cerner-tech-talks/index.html
+++ b/2013/11/cerner-tech-talks/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -281,16 +282,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2014/01/cerner-and-open-source/index.html
+++ b/2014/01/cerner-and-open-source/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -288,16 +289,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2014/01/sponsoring-the-apache-software-foundation/index.html
+++ b/2014/01/sponsoring-the-apache-software-foundation/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -276,16 +277,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/2014/01/the-raft-protocol-a-better-paxos/index.html
+++ b/2014/01/the-raft-protocol-a-better-paxos/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -300,16 +301,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/about/index.html
+++ b/about/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -232,16 +233,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/advanced-debugging/index.html
+++ b/blog/advanced-debugging/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -524,16 +525,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/alan-and-grace-an-origin-story/index.html
+++ b/blog/alan-and-grace-an-origin-story/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -354,16 +355,6 @@ passionate Cerner engineers dedicated to fostering Cerner’s Engineering cultur
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/archives/index.html
+++ b/blog/archives/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -1632,16 +1633,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/automated-deployment-with-apache-kafka/index.html
+++ b/blog/automated-deployment-with-apache-kafka/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -293,16 +294,6 @@ and let us know how it works for you.</p>
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/beadledom-simple-java-framework-for-building-rest-apis/index.html
+++ b/blog/beadledom-simple-java-framework-for-building-rest-apis/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -311,16 +312,6 @@ Here is the complete list of contributors who made Beadledom awesome.</p>
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/building-a-unified-ui-component-library/index.html
+++ b/blog/building-a-unified-ui-component-library/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -338,16 +339,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/cerner-and-the-apache-software-foundation/index.html
+++ b/blog/cerner-and-the-apache-software-foundation/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -278,16 +279,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/clara-rules-joins-cerner-open-source/index.html
+++ b/blog/clara-rules-joins-cerner-open-source/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -295,16 +296,6 @@ documentation on the <a href="http://www.clara-rules.org">clara-rules.org</a> si
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/closures-and-currying-in-javascript/index.html
+++ b/blog/closures-and-currying-in-javascript/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -627,16 +628,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/deploying-web-services-with-apache-tomcat-and-chef/index.html
+++ b/blog/deploying-web-services-with-apache-tomcat-and-chef/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -278,16 +279,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/devcon-word-cloud/index.html
+++ b/blog/devcon-word-cloud/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -385,16 +386,6 @@ we had 295 submissions for talks, ranging from a deep technical dive into the in
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/engineers-on-the-road-for-smart-and-fhir/index.html
+++ b/blog/engineers-on-the-road-for-smart-and-fhir/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -287,16 +288,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/fall-2016-shipit-day/index.html
+++ b/blog/fall-2016-shipit-day/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -345,16 +346,6 @@ December!</p>
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/girls-in-technology-movement-hour-of-code/index.html
+++ b/blog/girls-in-technology-movement-hour-of-code/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -286,16 +287,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/identifying-network-acl-issues-with-chef-locally/index.html
+++ b/blog/identifying-network-acl-issues-with-chef-locally/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -294,16 +295,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/intern-hackfest-2014/index.html
+++ b/blog/intern-hackfest-2014/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -292,16 +293,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/javascript-logging-we-can-do-better/index.html
+++ b/blog/javascript-logging-we-can-do-better/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -805,16 +806,6 @@ about proactive solutions.</p>
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/managing-30000-logging-events-per-day-with-splunk/index.html
+++ b/blog/managing-30000-logging-events-per-day-with-splunk/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -333,16 +334,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/micah-whitacre-recognition-blog/index.html
+++ b/blog/micah-whitacre-recognition-blog/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -298,16 +299,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/michelle-brush-receives-the-rising-trendsetter-stemmy-award/index.html
+++ b/blog/michelle-brush-receives-the-rising-trendsetter-stemmy-award/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -282,16 +283,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/migrating-from-eclipse-3.x-to-eclipse-4.x-the-iaware-story/index.html
+++ b/blog/migrating-from-eclipse-3.x-to-eclipse-4.x-the-iaware-story/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -350,16 +351,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/10/index.html
+++ b/blog/page/10/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/11/index.html
+++ b/blog/page/11/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/12/index.html
+++ b/blog/page/12/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -245,16 +246,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/2/index.html
+++ b/blog/page/2/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/3/index.html
+++ b/blog/page/3/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/4/index.html
+++ b/blog/page/4/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/5/index.html
+++ b/blog/page/5/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/6/index.html
+++ b/blog/page/6/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/7/index.html
+++ b/blog/page/7/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/8/index.html
+++ b/blog/page/8/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/page/9/index.html
+++ b/blog/page/9/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -367,16 +368,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/railsconf-2016-recap/index.html
+++ b/blog/railsconf-2016-recap/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -308,16 +309,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/scaling-people-with-apache-crunch/index.html
+++ b/blog/scaling-people-with-apache-crunch/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -560,16 +561,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/shipit-hackathon-mplus/index.html
+++ b/blog/shipit-hackathon-mplus/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -296,16 +297,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/shipit-vii-day-winter-2016/index.html
+++ b/blog/shipit-vii-day-winter-2016/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -445,16 +446,6 @@ case, with a different group of people. Just a fresh change of pace.</p></blockq
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/blog/the-plain-text-is-a-lie/index.html
+++ b/blog/the-plain-text-is-a-lie/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -612,16 +613,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/culture/index.html
+++ b/culture/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -238,16 +239,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -365,17 +366,6 @@
         <a href="{{url}}">{{title}}</a>
     </article>
   {{/entries}}
-</script>
-
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
 </script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">

--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -1,0 +1,16 @@
+$('document').ready(function() {
+  $('#search-query').lunrSearch({
+    indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
+    results : '#search-results',  // selector for containing search results element
+    entries : '.entries',         // selector for search entries containing element (contained within results above)
+    template: '#search-results-template'  // selector for Mustache.js template
+  });
+
+  $('#search-query').keydown(function(event){
+    if(event.keyCode == 13) {
+      event.preventDefault();
+      return false;
+    }
+  });
+});
+

--- a/open_source/index.html
+++ b/open_source/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -182,16 +183,6 @@
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">

--- a/tech_talks/index.html
+++ b/tech_talks/index.html
@@ -29,6 +29,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script>!window.jQuery && document.write(unescape('%3Cscript src="./javascripts/libs/jquery.min.js"%3E%3C/script%3E'))</script>
   <script src="/javascripts/octopress.js" type="text/javascript"></script>
+  <script src="/javascripts/application.js" type="text/javascript"></script>
   <script src="/javascripts/libs/bootstrap.min.js"></script>
 
   <link href="/atom.xml" rel="alternate" title="Engineering Health" type="application/atom+xml">
@@ -240,16 +241,6 @@ We will talk about the origins and history of Docker, explain its technical foun
   {{/entries}}
 </script>
 
-<script type="text/javascript">
-  $(function() {
-    $('#search-query').lunrSearch({
-      indexUrl: '/javascripts/index.json',   // Url for the .json file containing search index data
-      results : '#search-results',  // selector for containing search results element
-      entries : '.entries',         // selector for search entries containing element (contained within results above)
-      template: '#search-results-template'  // selector for Mustache.js template
-    });
-  });
-</script>
   <footer role="contentinfo" class="page-footer">
   <div class="container-fluid">
     <div class="row">


### PR DESCRIPTION
This resolves #55 

There was a lot of duplicate javascript code loading `lunrSearch` on every single page. We also didn't have a generic `application.js` to stick code that applies to the entire site.