### PR TITLE
Correcting Spring 2016 ShipIt post tags

### DIFF
--- a/source/_posts/2016-04-18-spring-2016-shipit-day.markdown
+++ b/source/_posts/2016-04-18-spring-2016-shipit-day.markdown
@@ -3,7 +3,7 @@ layout: post
 title: Spring 2016 ShipIt Day
 author: Melanie Carpenter
 date: 2016-04-18
-tags: [culture, engineering, hackathon, shipit]]
+tags: [culture, engineering, hackathon, shipit]
 ---
 
 ShipIt Day is an all day, all night hackathon with the goal of building something awesome, usable, and value-adding


### PR DESCRIPTION
Looks like on the change I applied in #53, caused an invalid array context into the tags section, which results in our page not being rendered correctly with the style.

This corrects the YAML block that it is trying to parse to understand how to format / style the page.

http://engineering.cerner.com/blog/spring-2016-shipit-day/