### PR TITLE
Adding Cerner and the SDLC blog

### DIFF
--- a/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
+++ b/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
@@ -65,7 +65,8 @@ Like the Agile Manifesto, the principles are simple, yet powerful:
 * Descaling Work
 * Enterprise-wide Agility
 * Nurture Culture
-* The Future
+
+### The Future
 
 The SDLC is currently viewed as the leader in business agility practices and is shaping the speakers and agendas for the [Business Agility Conferences](http://businessagilityconf.com/) globally. We continue to expand membership to include new companies who meet the criteria of a leader in agility and have a story to tell. Current members have grown to include Barclays Bank, Vistaprint, Fidelity Investments, Target, American Express, and All State are all candidates to join in 2018.
 

--- a/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
+++ b/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
@@ -6,8 +6,6 @@ date: 2018-01-23
 tags: [engineering, agile, learning]
 ---
 
-## Cerner and the SD Learning Consortium
-
 Cerner has a very compelling story that many want to learn from. Cerner’s Agile Champions are regular presenters at local, national, and global conferences. We routinely host calls and site visits for interested companies around the world who want to figure out how we were able to adopt Agile so quickly and sustain it so successfully. 
 
 Despite our success, there has been a general feeling at the engineering leadership and Agile Champion tiers that we aren’t getting the benefits from Agile that we once were. We talk Agile well, but have far too many teams that could be classified as "[cargo cult](https://www.solutionsiq.com/resource/blog-post/cargo-cult-agile-approach/)" - going through the motions rather than having an agile mindset. We were great teachers, but somehow had gone stagnant in our learning and growth.

--- a/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
+++ b/source/_posts/2018-01-23-cerner-and-the-sdlc.markdown
@@ -1,0 +1,75 @@
+---
+layout: post
+title: "Cerner and the SDLC"
+author: Matt Anderson
+date: 2018-01-23
+tags: [engineering, agile, learning]
+---
+
+## Cerner and the SD Learning Consortium
+
+Cerner has a very compelling story that many want to learn from. Cerner’s Agile Champions are regular presenters at local, national, and global conferences. We routinely host calls and site visits for interested companies around the world who want to figure out how we were able to adopt Agile so quickly and sustain it so successfully. 
+
+Despite our success, there has been a general feeling at the engineering leadership and Agile Champion tiers that we aren’t getting the benefits from Agile that we once were. We talk Agile well, but have far too many teams that could be classified as "[cargo cult](https://www.solutionsiq.com/resource/blog-post/cargo-cult-agile-approach/)" - going through the motions rather than having an agile mindset. We were great teachers, but somehow had gone stagnant in our learning and growth.
+
+Two events have ignited Cerner on a renewed learning journey that has already impacted Cerner in many business areas and allowed Cerner to help shape the future direction of business agility across the globe.
+
+### The Invitation
+
+Ironically, the first came shortly after delivering a presentation at Agile 2014 that included a section on avoiding cargo cult agile. [Ahmed Sidky](https://twitter.com/asidky), CEO of ICAgile, invited me to connect for a brief meeting. When our "brief meeting" stretched over several hours, we knew we had a strong partnership opportunity. Thus, was born the certification of Cerner’s Agile courses against an [independent, internationally recognized curriculum](https://icagile.com/Overview) and Cerner as one of ICAgile’s first Member Organizations.
+
+The second came shortly after Agile 2015 while hosting a call for CH Robinson and their delivery lead, [Vanessa Adams](https://twitter.com/jed2van). As the call wrapped up, Vanessa disclosed that she served on the board of directors for a newly formed group under the leadership of Steve Denning and Ahmed Sidky that was bringing together forward looking Agile companies to discover best practices in enterprise agility and share them back into the community. After talking with us, she felt that Cerner was an ideal candidate given our story and our willingness to learn and share.
+
+I was intrigued yet skeptical.
+
+I honestly didn’t know who [Steve Denning](https://twitter.com/stevedenning) was so being a part of the "Steve Denning Learning Consortium" held no appeal. I respected Ahmed as a voice in the Agile community that understood how to address real business issues with an Agile mindset. 
+
+Some quick research on Steve exposed his background in the business and banking world. He is an author and regular contributor to Forbes magazine and Harvard Business Review. While he had written books on Agile management and was on the Scrum Alliance board, my mental image was of a business school professor, not a practicing agilist.
+
+I voiced my concerns. Vanessa felt confident they would be resolved and invited us to attend an upcoming visit (May 2016) at Riot Games and Microsoft that would be partially hosted by Ahmed who had joined Riot Games as head of Delivery. 
+
+### Converting the Skeptic
+
+One of the keys to Cerner’s successful transformation was leveraging the idea of _Connectors_, _Mavens_, and _Salesmen_ along with _Skeptics_ as articulated by [Malcolm Gladwell](https://www.fastcompany.com/1799410/connectors-mavens-and-salesmen-how-new-ideas-spread-seeds) in our early pilot groups so we could address potential issues head on and build momentum. We were especially successful as some of the biggest _Skeptics_ were also _Connectors_ or _Mavens_ and they have been crucial to our broad adoption and continued sustainability. Our results were our best _Salesmen_.
+
+On Cerner’s first site visit to meet with the SD Learning Consortium, the roles played out again. [Microsoft, Riot Games, Ericsson, CH Robinson, Spotify](http://www.sdlearningconsortium.org/who-we-are/), Steve Denning, and a representative from the [Scrum Alliance](https://www.scrumalliance.org/) were all in attendance. Over the four days in LA and Seattle, we got to see inside Riot and Microsoft and see what was working as well as what wasn’t. The open and frank conversations as well as the "No BS" attitude among all participants was extremely refreshing and productive.
+
+At conferences, messages are polished and even "learning" (a.k.a. failure) is always painted in the best possible light. This was completely different. Failures that were failures were shared and discussed. Current experiments were both admired and challenged, often by the same individual.
+
+Probably the most significant moment for me was sitting next to [Joakim Sunden](https://twitter.com/joakimsunden) from Spotify, who co-authored what I still consider to be the best introductory book on Kanban for software development ([Kanban in Action](https://www.amazon.com/Kanban-Action-Marcus-Hammarberg/dp/1617291056)), and having him explain how the Spotify videos were created and what really goes on. (Hint – they are Marketing videos and highlight models that Spotify does not rigidly follow. They don’t know what the Spotify Way is that many talk about.)  Spotify is great, visionary and different, but they aren’t a unicorn or perfect. A future site visit to Spotify solidified that fact and made me respect them even more.
+
+I found that each existing member was a _Connector_ in their organizations, a _Maven_ in terms of enterprise agility, and a healthy _Skeptic_ towards the bulk of commercialized Agile. Ahmed was the _Salesman_. Steve was a little bit of the professor, but clearly demonstrated an Agile mindset and a vision to change the world of work. I caught his vision. It was refreshing and for the first time in several years, I learned several new things that I could try at Cerner as soon as I got back. The _Skeptic_ was converted.
+
+### Assessing and Applying at Cerner
+
+As I took a hard look at Cerner after returning from the visit, I realized that our success with things like [DevCon](http://engineering.cerner.com/2013/08/devcon/) and the [DevAcademy](http://engineering.cerner.com/2013/08/devacademy/) where we were truly industry trend setters had allowed us to be complacent in other areas that the other SDLC members had as strengths. In some cases, entropy was setting in and some of the benefits we realized from going Agile were no longer as prevalent. We weren’t in the danger zone, but some trends were heading in the wrong direction and merited a fresh look.
+
+In other cases, SDLC companies were branching out with experiments in areas like HR, Finance, or Marketing that were bearing fruit. Their success led to a desire to see what we could do at Cerner.
+
+Over the past two years, site visits have been held at Microsoft (Seattle), Ericsson (Stolkholm and Athelone Ireland), Barclays Bank (London), BMW (Munich), Riot Games (LA), Spotify (New York), Vistaprint (Boston), Fidelity Investments (Boston), CH Robinson (Chicago), and Cerner. Without exception, from each set of site visits, at least three action items have been taken by the Cerner attendees to improve Cerner. There is a renewed vigor towards an Agile mindset that had waned over the past 3-4 years.
+At the beginning, Shahzad Zafar and I were the only representatives for Cerner. Now we have four Cerner associates at each site visit and have many other associates engage in deep dive conversations on special topics like DevOps, Shadow IT, or HR.
+
+### Learning and Sharing
+
+Part of the SDLC is to learn from each other and then share those messages back into the broader community. There is deep, rich learning that can be gained from blending large companies like Ericcson with over 100K employees with a mid-tier company like Cerner (20K+), smaller companies like Vistaprint (5k+) and "born Agile" start-ups like Riot Games.
+
+While each SDLC member has software components as part of the services that we offer to our clients, we operate in different verticals. The lessons we learn are universal and are not limited to a specific market or niche.
+
+At the end of 2016, the SDLC members got together and [summarized our learnings](http://www.sdlearningconsortium.org/what-we-have-learned/) from the year in a paper that Steve then presented at the 2016 Drucker Forum.
+
+Personally, I have gone from the Skeptic to a very vocal evangelist, sharing the combined Cerner and SDLC story at the 2016 KC PMI Conference, [2016 LeanAgileKC](http://2016.leanagilekc.com/sessions/the-future-is-here/), 2017 Business Agility Conference, Agile 2017, 2017 Global PMI PMO Symposium as well as 2 of Cerner’s 2017 DevCons. Barclays Bank and Riot Games have been equally as active in sharing the SDLC learnings across the globe.
+
+Steve Denning recently published an [article in Forbes](https://www.forbes.com/sites/stevedenning/2017/10/15/what-is-agile-the-four-essential-elements/#24b8c3736e85) with the findings that are starting to be cited as the core fundamentals for business agility across the globe with Cerner listed as a prevalent contributor.
+
+Like the Agile Manifesto, the principles are simple, yet powerful:
+
+* Delighting Customers
+* Descaling Work
+* Enterprise-wide Agility
+* Nurture Culture
+* The Future
+
+The SDLC is currently viewed as the leader in business agility practices and is shaping the speakers and agendas for the [Business Agility Conferences](http://businessagilityconf.com/) globally. We continue to expand membership to include new companies who meet the criteria of a leader in agility and have a story to tell. Current members have grown to include Barclays Bank, Vistaprint, Fidelity Investments, Target, American Express, and All State are all candidates to join in 2018.
+
+The brightest future is not about the SDLC but about Cerner and what we can accomplish based on learning from other SDLC members. Our 2018 Vision aligns well with the SDLC learnings and several strategies to achieve our vision include models based on what other SDLC members have already proven to be successful.
+


### PR DESCRIPTION
Adding Cerner and the SDLC blog. Targeting to publish today.

![cerner-sdlc](https://user-images.githubusercontent.com/2358324/35291880-58c4cafe-0034-11e8-9d90-ba019751b8d8.png)

