### PR TITLE
test fix for ruby version travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - ruby-2.2.3
 script: bundle exec rake install; bundle exec rake generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - ruby-2.2.3
-script: bundle exec rake install; bundle exec rake generate
+script: bundle exec rake generate


### PR DESCRIPTION
test to see if this fixes the travis CI build

* Updated ruby version since it seems the 1.9 version in the travis yml file wasn't compatible
* Remove the install command. Its not listed in the updating guide and makes massive updates to the scss directory, so i didn' thtink it was realistic of a test case