### PR TITLE
Issue #163: Adding default image Open Graph tag

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,6 +50,8 @@ home = [ "HTML", "RSS", "JSON"]
   homepageImage = "/images/alan-grace.png"
   share = true
   showLanguageSwitcher = false
+  title = "Cerner Engineering"
+  images = ["/images/alan-grace.png"]
 
   [params.social]
     rss = true


### PR DESCRIPTION
Adding in base configuration which leverages the Hugo internal Open Graph template to include content on the heading of pages. 
https://gohugo.io/templates/internal/#configure-open-graph