### PR TITLE
Updating config to allow updates on copyright year

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 baseURL = "https://engineering.cerner.com"
 title = "Engineering Health"
-copyright = "Copyright © 2021"
 paginate = 10
 languageCode = "en"
 DefaultContentLanguage = "en"

--- a/themes/eh-theme/layouts/partials/footer.html
+++ b/themes/eh-theme/layouts/partials/footer.html
@@ -45,7 +45,7 @@
                     {{ if .Site.Copyright }}
                         {{ .Site.Copyright | safeHTML }}
                     {{ else }}
-                        Copyright &copy; {{ .Site.Title }} {{ now.Year }}
+                        Copyright &copy; {{ now.Year }}
                     {{ end }}
                 </p>
 


### PR DESCRIPTION
Allowing for dynamic copyright year updates in site, by not having it statically stored in config.