### PR TITLE
Changing About to be Careers with heading link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,11 @@ theme = "eh-theme"
     name = "Tech Talks"
     url = "/tech-talks/"
     weight = 4
+  [[menu.main]]
+    identifier = "careers"
+    name = "Careers"
+    url = "/careers/"
+    weight = 5
 
 [taxonomies]
 category = "categories"

--- a/content/careers.md
+++ b/content/careers.md
@@ -1,6 +1,7 @@
 ---
-title: "About"
+title: "Careers"
 description: "Life as an Engineer"
+aliases: ["/about/"] 
 ---
 
 At Cerner, we use the latest technologies to transform healthcare. We are the engineers and designers that focus on making you, your family, and friends healthy and happy.
@@ -9,4 +10,6 @@ We love solving the hard problems that no one else wants to tackle. We embrace p
 
 We also know that it’s important to allow engineers to take a step back to learn and try new things. That’s why we host periodic hackathons, meetups, [tech talks]({{<ref "/post/cerner-tech-talks">}}), and an [annual internal two-day developers conference]({{<ref "/post/devcon">}}). We also love to attend, sponsor, and speak at conferences.
 
-If this sounds interesting to you, we’d love to work together. Get it touch with us [here](http://www.cerner.com/careers).
+If this sounds interesting to you, we’d love to work together. Get it touch with us [here](https://careers.cerner.com/paths/engineering--technology).
+
+{{< youtube Tqmz4XnaQdA >}}


### PR DESCRIPTION
Including a "Careers" link at the top of the site. We had an existing "About" page that wasn't really referenced anymore. So, I changed this to be the Careers reference, which also includes updating the link to the careers.cerner.com site for Engineering and Technology jobs. On this page, included an embedded video for Cerner technical careers.